### PR TITLE
fix: copy the latest content from the `main` branch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,11 +50,11 @@ jobs:
         ref: gh-pages
         fetch-depth: 0
         
-    - name: Copy latest plots and data
+    - name: Copy latest content from main
       run: |
         git fetch origin main
-        git checkout origin/main -- out/plots/
-        git checkout origin/main -- README.md
+        git checkout origin/main -- .
+        git checkout HEAD -- .git
         
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/nightly.yml` file. The change updates the job that copies the latest content from the `main` branch.

Workflow updates:

* [`.github/workflows/nightly.yml`](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6L53-R57): Modified the job name to "Copy latest content from main" and updated the commands to checkout all contents from the `main` branch and reset the `.git` directory.