### PR TITLE
remove checkout .git from gh action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,7 +54,6 @@ jobs:
       run: |
         git fetch origin main
         git checkout origin/main -- .
-        git checkout HEAD -- .git
         
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/nightly.yml` file. The change removes the line that checks out the `.git` directory. 

* [`.github/workflows/nightly.yml`](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6L57): Removed the line `git checkout HEAD -- .git` to prevent unnecessary checkout of the `.git` directory.