### PR TITLE
Feat/t1 t2 website

### DIFF
--- a/_includes/metrics_grid.html
+++ b/_includes/metrics_grid.html
@@ -43,4 +43,17 @@
             <a class="link" href="" target="_blank">View paper <span class="external-link-icon">↗</span></a>
         </div>
     </div>
+    
+    <div class="metric-card" id="coherence-times-metric">
+        <h3>Qubit Coherence Times</h3>
+        <p>Latest T1 and T2 values for physical qubits</p>
+        <div class="metric-value">
+            <span class="code-name"></span>
+            <span class="t1-value"></span>
+            <span class="t2-value"></span>
+            <span class="platform"></span>
+            <span class="year"></span>
+            <a class="link" href="" target="_blank">View paper <span class="external-link-icon">↗</span></a>
+        </div>
+    </div>
 </div> 

--- a/_includes/plots_grid.html
+++ b/_includes/plots_grid.html
@@ -18,4 +18,9 @@
         <h3>Qubit Count Evolution</h3>
         <div id="qubit-count-plot" style="width:100%; height:500px;"></div>
     </div>
+
+    <div class="plot-card">
+        <h3>Physical Qubit Coherence Times</h3>
+        <div id="coherence-times-plot" style="width:100%; height:500px;"></div>
+    </div>
 </div> 

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -30,7 +30,7 @@
             }
         }
         
-        .count, .error-rate, .code-params, .msd-code-name {
+        .count, .error-rate, .code-params, .msd-code-name, .code-name {
             font-size: 1.25rem;
             font-weight: bold;
             color: $link-color;

--- a/assets/js/data-loader.js
+++ b/assets/js/data-loader.js
@@ -140,6 +140,37 @@ function loadCSV(url, tableId) {
                         }
                     ];
                     break;
+                case 'physical-qubits-table':
+                    columnDefs = [
+                        { 
+                            title: "Year",
+                            data: findColumn(headers, ["Year", "year", "Date", "date"]) || "Year"
+                        },
+                        { 
+                            title: "Platform",
+                            data: findColumn(headers, ["Platform", "platform", "Implementation"]) || "Platform"
+                        },
+                        {
+                            title: "Code Name",
+                            data: findColumn(headers, ["Code Name", "code_name", "Code", "code"]) || "Code Name"
+                        },
+                        {
+                            title: "T1",
+                            data: findColumn(headers, ["T1", "t1", "T1 Time"]) || "T1"
+                        },
+                        {
+                            title: "T2",
+                            data: findColumn(headers, ["T2", "t2", "T2 Time"]) || "T2"
+                        },
+                        { 
+                            title: "Link",
+                            data: findColumn(headers, ["Link", "URL", "DOI", "link"]) || "Link",
+                            render: function(data) {
+                                return data ? `<a href="${data}" target="_blank">Link</a>` : '';
+                            }
+                        }
+                    ];
+                    break;
             }
 
             try {
@@ -169,6 +200,9 @@ function loadCSV(url, tableId) {
                         break;
                     case 'entangled-table':
                         createEntangledErrorPlot(results.data);
+                        break;
+                    case 'physical-qubits-table':
+                        createCoherenceTimesPlot(results.data);
                         break;
                 }
                 
@@ -240,6 +274,17 @@ function updateMetricsGrid(tableId, data) {
             $('#msd-metric .year').text(latest.Year || '');
             updateLink('#msd-metric', latest.Link);
             break;
+
+        case 'physical-qubits-table':  // Update for coherence times
+            const t1Value = latest['T1'] ? `${latest['T1']} s` : 'N/A';
+            const t2Value = latest['T2'] ? `${latest['T2']} s` : 'N/A';
+            $('#coherence-times-metric .t1-value').text(`T1: ${t1Value}`);
+            $('#coherence-times-metric .t2-value').text(`T2: ${t2Value}`);
+            $('#coherence-times-metric .platform').text(latest.Platform || '');
+            $('#coherence-times-metric .code-name').text(latest['Code Name'] || 'N/A');
+            $('#coherence-times-metric .year').text(latest.Year || '');
+            updateLink('#coherence-times-metric', latest.Link);
+            break;
     }
 }
 
@@ -293,4 +338,5 @@ $(document).ready(function() {
     loadCSV('https://raw.githubusercontent.com/francois-marie/awesome-quantum-computing-experiments/main/data/msd_exp.csv', 'msd-table');
     loadCSV('https://raw.githubusercontent.com/francois-marie/awesome-quantum-computing-experiments/main/data/entangled_state_error_exp.csv', 'entangled-table');
     loadCSV('https://raw.githubusercontent.com/francois-marie/awesome-quantum-computing-experiments/main/data/qubit_count.csv', 'qubit-count-table');
+    loadCSV('https://raw.githubusercontent.com/francois-marie/awesome-quantum-computing-experiments/main/data/physical_qubits.csv', 'physical-qubits-table');
 }); 

--- a/assets/js/plot-loader.js
+++ b/assets/js/plot-loader.js
@@ -148,3 +148,78 @@ function createEntangledErrorPlot(data) {
 
     Plotly.newPlot('entangled-error-plot', traces, layout, config);
 }
+
+function createCoherenceTimesPlot(data) {
+    const platforms = [...new Set(data.map(d => d.Platform))];
+    const traces = [];
+    
+    platforms.forEach(platform => {
+        const platformData = data.filter(d => d.Platform === platform);
+        
+        // T1 trace
+        const t1Data = platformData.filter(d => d.T1 && d.T1 !== '');
+        if (t1Data.length > 0) {
+            traces.push({
+                name: `${platform} (T1)`,
+                type: 'scatter',
+                mode: 'lines+markers',
+                x: t1Data.map(d => d.Year),
+                y: t1Data.map(d => d.T1),
+                text: t1Data.map(d => d['Article Title'] || d['Code Name']),
+                customdata: t1Data.map(d => d.Link || ''),
+                hovertemplate: 
+                    '<b>%{text}</b><br>' +
+                    'T1: %{y}s<br>' +
+                    'Year: %{x}<br>' +
+                    '%{customdata}<extra></extra>',
+                marker: { symbol: 'circle' }
+            });
+        }
+        
+        // T2 trace
+        const t2Data = platformData.filter(d => d.T2 && d.T2 !== '');
+        if (t2Data.length > 0) {
+            traces.push({
+                name: `${platform} (T2)`,
+                type: 'scatter',
+                mode: 'lines+markers',
+                x: t2Data.map(d => d.Year),
+                y: t2Data.map(d => d.T2),
+                text: t2Data.map(d => d['Article Title'] || d['Code Name']),
+                customdata: t2Data.map(d => d.Link || ''),
+                hovertemplate: 
+                    '<b>%{text}</b><br>' +
+                    'T2: %{y}s<br>' +
+                    'Year: %{x}<br>' +
+                    '%{customdata}<extra></extra>',
+                marker: { symbol: 'circle-open' }
+            });
+        }
+    });
+
+    const layout = {
+        title: 'Evolution of Qubit Coherence Times',
+        xaxis: { 
+            title: 'Year',
+            dtick: 1  // Force integer ticks
+        },
+        yaxis: { 
+            title: 'Coherence Time (s)',
+            type: 'log'
+        },
+        hovermode: 'closest',
+        showlegend: true,
+        legend: {
+            x: 0,
+            y: 1
+        }
+    };
+
+    const config = {
+        responsive: true,
+        displayModeBar: true,
+        modeBarButtons: [['zoom2d', 'pan2d', 'resetScale2d', 'toImage']]
+    };
+
+    Plotly.newPlot('coherence-times-plot', traces, layout, config);
+}

--- a/experiments.md
+++ b/experiments.md
@@ -46,6 +46,17 @@ Tracking the evolution of physical qubit counts across different quantum computi
 
 <table id="qubit-count-table" class="display responsive nowrap" width="100%"></table>
 
+## Physical Qubit Coherence Times
+This database tracks the evolution of coherence times (T1 and T2) across different physical qubit implementations.
+
+### Key Metrics:
+- T1 (Energy relaxation time)
+- T2 (Dephasing time)
+- Platform
+- Year
+
+<table id="physical-qubits-table" class="display responsive nowrap" width="100%"></table>
+
 ## Contributing
 
 Have a new experiment to add? Check our [Contributing Guide](docs/CONTRIBUTING.md) for instructions on how to submit new entries.

--- a/index.md
+++ b/index.md
@@ -26,6 +26,9 @@ A comprehensive collection of notable quantum computing experiments, focusing on
 ### Qubit Count Evolution
 <div id="qubit-count-plot" style="width:100%; height:500px;"></div>
 
+### Physical Qubit Coherence Times
+<div id="coherence-times-plot" style="width:100%; height:500px;"></div>
+
 ## About
 
 This database tracks:


### PR DESCRIPTION
This pull request includes several changes to add and display data about physical qubit coherence times. The most important changes include adding new sections to display coherence times in the metrics and plots grids, updating the data loader to handle the new data, and creating a new plot for coherence times.

### Additions to display coherence times:

* [`_includes/metrics_grid.html`](diffhunk://#diff-5ae64ba32912fc1ff481eb5f64118150a741e0fb4b95fd68e62846bf1a87d450R46-R58): Added a new metric card for "Qubit Coherence Times" to display the latest T1 and T2 values for physical qubits.
* [`_includes/plots_grid.html`](diffhunk://#diff-f5004ebfd561ae2846d53eef32008deaafa4386acff99f81d7aa45021dd3655fR21-R25): Added a new plot card for "Physical Qubit Coherence Times" to display a plot of coherence times.
* [`index.md`](diffhunk://#diff-a48746cae70c44e7e105b594aad338ddd105c93c1cb445a40ba6aab785ba69e5R29-R31): Added a new section to display the coherence times plot on the main index page.
* [`experiments.md`](diffhunk://#diff-6c093d5097a05418791d10fbe9529fcac170a5b12d802c9de806ffe057159c3eR49-R59): Added a new section to display a table for physical qubit coherence times and described key metrics.

### Updates to data loader:

* [`assets/js/data-loader.js`](diffhunk://#diff-3c114d4d13ae28c2a530963ca6f74b6e5522b24ef17df55ab7574ed8aebf7bcaR143-R173): Updated the `loadCSV` function to handle the new 'physical-qubits-table' and create a coherence times plot. Also updated the `updateMetricsGrid` function to display the latest coherence times data in the metrics grid. [[1]](diffhunk://#diff-3c114d4d13ae28c2a530963ca6f74b6e5522b24ef17df55ab7574ed8aebf7bcaR143-R173) [[2]](diffhunk://#diff-3c114d4d13ae28c2a530963ca6f74b6e5522b24ef17df55ab7574ed8aebf7bcaR204-R206) [[3]](diffhunk://#diff-3c114d4d13ae28c2a530963ca6f74b6e5522b24ef17df55ab7574ed8aebf7bcaR277-R287) [[4]](diffhunk://#diff-3c114d4d13ae28c2a530963ca6f74b6e5522b24ef17df55ab7574ed8aebf7bcaR341)

### New plot creation:

* [`assets/js/plot-loader.js`](diffhunk://#diff-3df0c8d14f7c719101eca633a90bd6c2e9c972108a8ee45b6c3100d3e164c55aR151-R225): Added a new function `createCoherenceTimesPlot` to generate a plot for the evolution of qubit coherence times (T1 and T2) across different platforms.

### Styling updates:

* [`_sass/custom/custom.scss`](diffhunk://#diff-763ac3523acb81380882833d64791adae805b37ea3429ea95cb44b8f5c439593L33-R33): Added styling for the new `.code-name` class to ensure consistency with other metric cards.