### PR TITLE
change the pip install

### DIFF
--- a/src/markdown/generator.py
+++ b/src/markdown/generator.py
@@ -67,7 +67,7 @@ This repository maintains a comprehensive database of quantum computing experime
 ```bash
 git clone https://github.com/francois-marie/awesome-quantum-computing-experiments.git
 cd awesome-quantum-computing-experiments
-pip install -r requirements.txt
+pip install -e ".[test]" # Install package and test dependencies
 ```
 
 2. Generate all plots and README:


### PR DESCRIPTION
This pull request includes a small change to the `src/markdown/generator.py` file. The change updates the installation command (including test dependencies).

* [`src/markdown/generator.py`](diffhunk://#diff-2f1d37315280298b4218fe01d723c54a5ea45b51bc3160c47c6cec12a3fbc071L70-R70): Modified the pip install command to use `-e ".[test]"`, ensuring both the package and test dependencies are installed.