### PR TITLE
Update entangled_state_error_exp.csv

### DIFF
--- a/data/entangled_state_error_exp.csv
+++ b/data/entangled_state_error_exp.csv
@@ -20,4 +20,4 @@
 "0.002","Erasure conversion in a high-fidelity Rydberg quantum simulator","https://arxiv.org/abs/2305.03406","2023","Neutral atoms",""
 "","High fidelity state preparation, quantum control, and readout of an isotopically enriched silicon spin qubit","https://arxiv.org/abs/2204.09551","2022","Superconducting spins",""
 "0.005","Fast universal quantum control above the fault-tolerance threshold in silicon","https://arxiv.org/abs/2108.02626","2021","Superconducting spins",""
-"0.05","Quantum logic with spin qubits crossing the surface code threshold","https://www.nature.com/articles/s41586-021-04273-w","2022","Superconducting spins",""
+"0.0035","Quantum logic with spin qubits crossing the surface code threshold","https://www.nature.com/articles/s41586-021-04273-w","2022","Superconducting spins",""


### PR DESCRIPTION
This pull request includes a small change to the `data/entangled_state_error_exp.csv` file. The change updates the error rate for a specific quantum logic entry.

* [`data/entangled_state_error_exp.csv`](diffhunk://#diff-804f64c9308ffe26d647d0e4aab24278fb4b275719bd1c226e1c4fac93a6bd35L23-R23): Updated the error rate for "Quantum logic with spin qubits crossing the surface code threshold" from `0.05` to `0.0035`.