### PR TITLE
Update qec_exp.csv

### DIFF
--- a/data/qec_exp.csv
+++ b/data/qec_exp.csv
@@ -55,3 +55,4 @@
 "Color Code","Experimental Demonstration of Logical Magic State Distillation","https://arxiv.org/abs/2412.15165","2024","[[7, 1, 3]], [[17,1,5]]","Neutral atoms","","0","3%, 0.4%","0","",""
 "Color Code","Scaling and logic in the color code on a superconducting quantum processor","https://arxiv.org/abs/2412.14256","2024","[[7, 1, 3]], [[17,1,5]]","Superconducting circuit","","30","100%","6, 18","",""
 "Surface Code","Demonstrating dynamic surface codes","https://arxiv.org/abs/2412.14360","2024","[[9,1,3]], [[25,1,5]]","Superconducting circuit","","54","100%","8, 24","",""
+"Repetition Code","Realization of quantum error correction","https://doi.org/10.1038/nature03074","2004","[3,1,3]","Ion traps","","1","100%","0","?","?"


### PR DESCRIPTION
This pull request includes a small update to the `data/qec_exp.csv` file. The change involves adding a new entry for a research paper related to quantum error correction.

* [`data/qec_exp.csv`](diffhunk://#diff-0202903bc12b1b52c861ab5dcf26cff1a5a8e4f8c2e14071cd029d7907fe25d4R58): Added a new entry for the paper "Realization of quantum error correction" published in 2004, detailing its use of ion traps and providing relevant metadata.