### PR TITLE
Update physical_qubits.csv

### DIFF
--- a/data/physical_qubits.csv
+++ b/data/physical_qubits.csv
@@ -23,3 +23,7 @@
 "Gatemon","Gatemon Benchmarking and Two-Qubit Operation","https://arxiv.org/abs/1512.09195","2016","Semiconductor","semiconductor Josephson junction","","0.000003",""
 "Gatemon","Evolution of Nanowire Transmons and Their Quantum Coherence in Magnetic Field","https://arxiv.org/abs/1711.07961","2018","Semiconductor","semiconductor Josephson junction","","0.00001",""
 "Gatemon","Quantum coherent control of a hybrid superconducting circuit made with graphene-based van der Waals heterostructures","https://arxiv.org/abs/1809.05215","2018","Graphene","graphene Josephson junction","","0.00000005",""
+"Ytterbium","Single ion qubit with estimated coherence time exceeding one hour","https://doi.org/10.1038/s41467-020-20330-w","2021","Ion traps","S1/2 mF=0 hyperfine levels","","","5500"
+"Ytterbium","Single-qubit quantum memory exceeding ten-minute coherence time","https://doi.org/10.1038/s41566-017-0007-1","2017","Ion traps","S1/2 mF=0 hyperfine levels","","","667"
+"Beryllium","Long-Lived Qubit Memory Using Atomic Ions","https://doi.org/10.1103/PhysRevLett.95.060502","2005","Ion traps","2s2S1/2 F=1, mF=1 and F=2, mF=2","","","14.7"
+"Calcium","High-Fidelity Preparation, Gates, Memory, and Readout of a Trapped-Ion Quantum Bit","https://doi.org/10.1103/PhysRevLett.113.220501","2014","Ion traps","hyperfine atomic-clock states","","","50"


### PR DESCRIPTION
This pull request adds new entries to the `data/physical_qubits.csv` file, expanding the dataset to include more types of ion trap qubits and their respective coherence times.

New entries added to `data/physical_qubits.csv`:

* Added Ytterbium qubit with a coherence time exceeding one hour.
* Added Ytterbium qubit with a ten-minute coherence time.
* Added Beryllium qubit with a coherence time of 14.7 seconds.
* Added Calcium qubit with a coherence time of 50 seconds.