### PR TITLE
Update entangled_state_error_exp.csv

### DIFF
--- a/data/entangled_state_error_exp.csv
+++ b/data/entangled_state_error_exp.csv
@@ -21,3 +21,4 @@
 "0.005","Fast universal quantum control above the fault-tolerance threshold in silicon","https://arxiv.org/abs/2108.02626","2021","Superconducting spins",""
 "0.0035","Quantum logic with spin qubits crossing the surface code threshold","https://www.nature.com/articles/s41586-021-04273-w","2022","Superconducting spins",""
 "0,04","Robust entanglement","https://doi.org/10.1007/s00340-005-1917-z","2005","Ion traps","Entangled states of two trapped Ca+ ions with robust entanglement lasting for more than 20 s."
+"0,0003","Scalable, high-fidelity all-electronic control of trapped-ion qubits","https://arxiv.org/abs/2407.07694","2024","Ion traps",""


### PR DESCRIPTION
This pull request includes an update to the `data/entangled_state_error_exp.csv` file. The change involves adding a new entry to the dataset.

Data update:

* [`data/entangled_state_error_exp.csv`](diffhunk://#diff-804f64c9308ffe26d647d0e4aab24278fb4b275719bd1c226e1c4fac93a6bd35R24): Added a new entry for a 2024 paper titled "Scalable, high-fidelity all-electronic control of trapped-ion qubits" with an error rate of 0.0003.