### PR TITLE
Update entangled_state_error_exp.csv

### DIFF
--- a/data/entangled_state_error_exp.csv
+++ b/data/entangled_state_error_exp.csv
@@ -20,5 +20,5 @@
 "0.002","Erasure conversion in a high-fidelity Rydberg quantum simulator","https://arxiv.org/abs/2305.03406","2023","Neutral atoms",""
 "0.005","Fast universal quantum control above the fault-tolerance threshold in silicon","https://arxiv.org/abs/2108.02626","2021","Superconducting spins",""
 "0.0035","Quantum logic with spin qubits crossing the surface code threshold","https://www.nature.com/articles/s41586-021-04273-w","2022","Superconducting spins",""
-"0,04","Robust entanglement","https://doi.org/10.1007/s00340-005-1917-z","2005","Ion traps","Entangled states of two trapped Ca+ ions with robust entanglement lasting for more than 20 s."
-"0,0003","Scalable, high-fidelity all-electronic control of trapped-ion qubits","https://arxiv.org/abs/2407.07694","2024","Ion traps",""
+"0.04","Robust entanglement","https://doi.org/10.1007/s00340-005-1917-z","2005","Ion traps","Entangled states of two trapped Ca+ ions with robust entanglement lasting for more than 20 s."
+"0.0003","Scalable, high-fidelity all-electronic control of trapped-ion qubits","https://arxiv.org/abs/2407.07694","2024","Ion traps",""


### PR DESCRIPTION
This pull request includes corrections to the `data/entangled_state_error_exp.csv` file. The changes fix the formatting of numerical values to ensure consistency.

Formatting corrections:

* Corrected the numerical values from "0,04" to "0.04" and "0,0003" to "0.0003" to maintain consistent decimal notation.