### PR TITLE
Update physical_qubits.csv

### DIFF
--- a/data/physical_qubits.csv
+++ b/data/physical_qubits.csv
@@ -29,5 +29,5 @@
 "Hyperfine atomic-clock states","High-Fidelity Preparation, Gates, Memory, and Readout of a Trapped-Ion Quantum Bit","https://doi.org/10.1103/PhysRevLett.113.220501","2014","Ion traps","Calcium","","","50"
 "Cat encoding","Exponential suppression of bit-flips in a qubit encoded in an oscillator","https://doi.org/10.1038/s41567-020-0824-x","2019","Superconducting circuit","Bosonic","","0.001",""
 "Cat encoding","One Hundred Second Bit-Flip Time in a Two-Photon Dissipative Oscillator","https://doi.org/10.1103/PRXQuantum.4.020350","2023","Superconducting circuit","Bosonic","127",""
-"Cat encoding","Quantum control of a cat-qubit with bit-flip times exceeding ten seconds","https://doi.org/10.1038/s41586-024-07294-3","2024","Superconducting circuit","Bosonic","15","0,0000005"
+"Cat encoding","Quantum control of a cat-qubit with bit-flip times exceeding ten seconds","https://doi.org/10.1038/s41586-024-07294-3","2024","Superconducting circuit","Bosonic","15","0.0000005"
 "Cat encoding","Autoparametric resonance extending the bit-flip time of a cat qubit up to 0.3 s","https://doi.org/10.1103/PhysRevX.14.021019","2024","Superconducting circuit","Bosonic","0.3",""


### PR DESCRIPTION
This pull request includes a small but important change to the `data/physical_qubits.csv` file. The change corrects the formatting of a numerical value in the "Cat encoding" row to ensure consistency and accuracy.

* Corrected the formatting of the bit-flip time value from "0,0000005" to "0.0000005" in the "Cat encoding" row. (`data/physical_qubits.csv`)