### PR TITLE
Update physical_qubits.csv

### DIFF
--- a/data/physical_qubits.csv
+++ b/data/physical_qubits.csv
@@ -32,3 +32,4 @@
 "Cat encoding","Quantum control of a cat-qubit with bit-flip times exceeding ten seconds","https://doi.org/10.1038/s41586-024-07294-3","2024","Superconducting circuit","Bosonic","","15","0.0000005"
 "Cat encoding","Autoparametric resonance extending the bit-flip time of a cat qubit up to 0.3 s","https://doi.org/10.1103/PhysRevX.14.021019","2024","Superconducting circuit","Bosonic","","0.3",""
 "Hyperfine","A tweezer array with 6100 highly coherent atomic qubits","https://doi.org/10.48550/arXiv.2403.12021","2024","Neutral atom","","","119","12.6"
+"Hyperfine","Fast Quantum State Control of a Single Trapped Neutral Atom","https://doi.org/10.1103/PhysRevA.75.040301","2007","Neutral atom","Rubidium","Spin-echo, dephasing time of 370µs","","0.034"

--- a/data/physical_qubits.csv
+++ b/data/physical_qubits.csv
@@ -32,4 +32,4 @@
 "Cat encoding","Quantum control of a cat-qubit with bit-flip times exceeding ten seconds","https://doi.org/10.1038/s41586-024-07294-3","2024","Superconducting circuit","Bosonic","","15","0.0000005"
 "Cat encoding","Autoparametric resonance extending the bit-flip time of a cat qubit up to 0.3 s","https://doi.org/10.1103/PhysRevX.14.021019","2024","Superconducting circuit","Bosonic","","0.3",""
 "Hyperfine","A tweezer array with 6100 highly coherent atomic qubits","https://doi.org/10.48550/arXiv.2403.12021","2024","Neutral atom","","","119","12.6"
-"Hyperfine","Fast Quantum State Control of a Single Trapped Neutral Atom","https://doi.org/10.1103/PhysRevA.75.040301","2007","Neutral atom","Rubidium","Spin-echo, dephasing time of 370µs","","0.034"
+"Hyperfine","Fast Quantum State Control of a Single Trapped Neutral Atom","https://doi.org/10.1103/PhysRevA.75.040301","2007","Neutral atom","Rubidium","Spin-echo, dephasing time of 370µs. T1=trap lifetime in the absence of any near-resonant light","3","0.034"


### PR DESCRIPTION
This pull request includes an update to the `data/physical_qubits.csv` file. The change adds a new entry for a research paper on the fast quantum state control of a single trapped neutral atom. 

* Added a new entry for the paper titled "Fast Quantum State Control of a Single Trapped Neutral Atom" with details including the publication year (2007), technology (Neutral atom), material (Rubidium), and additional notes on spin-echo and dephasing time.