### PR TITLE
67 add coherence times for neutral atoms

### DIFF
--- a/data/physical_qubits.csv
+++ b/data/physical_qubits.csv
@@ -35,3 +35,4 @@
 "Hyperfine","Fast Quantum State Control of a Single Trapped Neutral Atom","https://doi.org/10.1103/PhysRevA.75.040301","2007","Neutral atoms","Rubidium","Spin-echo, dephasing time of 370µs. T1=trap lifetime in the absence of any near-resonant light","3","0.034"
 "e spin","One-second coherence for a single electron spin coupled to a multi-qubit nuclear-spin environment","https://doi.org/10.1038/s41467-018-04916-z","2018","NV centers","Diamond","","3600","1.58"
 "Hyperfine","A quantum processor based on coherent transport of entangled atom arrays","https://doi.org/10.1038/s41586-022-04592-6","2022","Neutral atoms","Rubidium","","4","1.5"
+"Hyperfine","Multi-qubit entanglement and algorithms on a neutral-atom quantum computer","https://doi.org/10.1038/s41586-022-04603-6","2022","Neutral atoms","Cesium","T2 using a XY8 pulse","4","1"

--- a/data/physical_qubits.csv
+++ b/data/physical_qubits.csv
@@ -34,3 +34,4 @@
 "Hyperfine","A tweezer array with 6100 highly coherent atomic qubits","https://doi.org/10.48550/arXiv.2403.12021","2024","Neutral atoms","","","119","12.6"
 "Hyperfine","Fast Quantum State Control of a Single Trapped Neutral Atom","https://doi.org/10.1103/PhysRevA.75.040301","2007","Neutral atoms","Rubidium","Spin-echo, dephasing time of 370µs. T1=trap lifetime in the absence of any near-resonant light","3","0.034"
 "e spin","One-second coherence for a single electron spin coupled to a multi-qubit nuclear-spin environment","https://doi.org/10.1038/s41467-018-04916-z","2018","NV centers","Diamond","","3600","1.58"
+"Hyperfine","A quantum processor based on coherent transport of entangled atom arrays","https://doi.org/10.1038/s41586-022-04592-6","2022","Neutral atoms","Rubidium","","4","1.5"

--- a/data/physical_qubits.csv
+++ b/data/physical_qubits.csv
@@ -36,3 +36,4 @@
 "e spin","One-second coherence for a single electron spin coupled to a multi-qubit nuclear-spin environment","https://doi.org/10.1038/s41467-018-04916-z","2018","NV centers","Diamond","","3600","1.58"
 "Hyperfine","A quantum processor based on coherent transport of entangled atom arrays","https://doi.org/10.1038/s41586-022-04592-6","2022","Neutral atoms","Rubidium","","4","1.5"
 "Hyperfine","Multi-qubit entanglement and algorithms on a neutral-atom quantum computer","https://doi.org/10.1038/s41586-022-04603-6","2022","Neutral atoms","Cesium","T2 using a XY8 pulse","4","1"
+"Hyperfine","2000-times repeated imaging of strontium atoms in clock-magic tweezer arrays","https://doi.org/10.1103/PhysRevLett.122.173201","2019","Neutral atoms","Strontium","","420",""


### PR DESCRIPTION
This pull request updates the `data/physical_qubits.csv` file by adding new entries that document recent advancements in neutral-atom quantum computing. The additions include details about quantum processors, multi-qubit entanglement, and imaging techniques.

Key changes:

* Added three new entries to the `data/physical_qubits.csv` file:
  - A 2022 study on a quantum processor using coherent transport of entangled atom arrays (`Hyperfine`, `Rubidium`).
  - A 2022 study on multi-qubit entanglement and algorithms on a neutral-atom quantum computer (`Hyperfine`, `Cesium`).
  - A 2019 study on repeated imaging of strontium atoms in clock-magic tweezer arrays (`Hyperfine`, `Strontium`).