### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,27 @@ jobs:
       run: |
         make all
     
+    - name: Check generated files
+      run: |
+        echo "=== Checking generated files ==="
+        ls -la out/
+        echo "=== JS files ==="
+        ls -la out/js/ || echo "JS directory not found"
+        echo "=== PNG files ==="
+        ls -la out/png/ || echo "PNG directory not found"
+        echo "=== Git status before adding ==="
+        git status --porcelain out/ || true
+    
     - name: Commit and push if changed
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
+        # Explicitly add the generated files
+        mkdir -p out/js out/png out/plots
+        git add out/js/*.js out/png/*.png out/plots/*.pdf README.md || true
         git add -A
+        echo "=== Git status after adding ==="
+        git status --porcelain || true
+        echo "=== Files to be committed ==="
+        git diff --staged --name-only || true
         git diff --quiet && git diff --staged --quiet || (git commit -m "Update plots and README [skip ci]" && git push) 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -5,11 +5,15 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'))
     
     steps:
     - name: Checkout main branch first
@@ -17,6 +21,13 @@ jobs:
       with:
         ref: main
         fetch-depth: 0
+    
+    - name: Verify generated files exist
+      run: |
+        echo "=== Checking for generated files on main branch ==="
+        ls -la out/ || echo "No out directory"
+        ls -la out/js/ || echo "No JS files"
+        ls -la out/png/ || echo "No PNG files"
     
     - name: Clean workspace
       run: |

--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,16 @@ sass:
   style: compressed
   sourcemap: never
 
+# Include generated plot files in the site
+include:
+  - out/js
+  - out/png
+  - out/plots
+
+# Keep the generated files during Jekyll build
+keep_files:
+  - out
+
 plugins:
   - jekyll-remote-theme
 


### PR DESCRIPTION
This pull request introduces updates to the CI and deployment workflows along with modifications to the Jekyll site configuration to better handle generated files. Key changes include adding checks for generated files, ensuring their inclusion during deployment, and updating conditions for triggering the `deploy-pages` workflow.

### Workflow updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR58-R80): Added steps to check the existence of generated files (`out/js`, `out/png`) and display their status before committing. Explicitly added generated files to the commit to ensure they are tracked.

* [`.github/workflows/deploy-pages.yml`](diffhunk://#diff-0f132b0962009071404990a6789b3466dbd8723d1f7b744f6aca0312396a7900R8-R16): Updated the workflow trigger to include runs from the `CI` workflow and added a condition to deploy only if the `workflow_run` event concludes successfully.

* [`.github/workflows/deploy-pages.yml`](diffhunk://#diff-0f132b0962009071404990a6789b3466dbd8723d1f7b744f6aca0312396a7900R25-R31): Added a step to verify the existence of generated files (`out/js`, `out/png`) on the main branch before cleaning the workspace.

### Jekyll configuration updates:

* [`_config.yml`](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883R33-R42): Included generated plot files (`out/js`, `out/png`, `out/plots`) in the site and ensured they are retained during the Jekyll build process.