### PR TITLE
Fix SEO

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :jekyll_plugins do
   gem "jekyll-remote-theme"
   gem "jekyll-include-cache"
   gem "jekyll-feed", "~> 0.15"
+  gem "jekyll-seo-tag"
 end
 
 # Compatible versions for Ruby 3.1

--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,25 @@ theme: just-the-docs
 baseurl: "/awesome-quantum-computing-experiments"
 url: "https://francoismarieleregent.xyz"
 
+# Add Twitter and social media configuration for Jekyll SEO plugin
+twitter:
+  username: fm_leregent
+  card: summary_large_image
+
+# Social media settings
+social:
+  name: François-Marie Le Régent
+  links:
+    - https://twitter.com/fm_leregent
+    - https://github.com/francois-marie
+
+# Default social image
+defaults:
+  - scope:
+      path: ""
+    values:
+      image: /assets/social_image.png
+
 # Theme settings
 color_scheme: custom
 search_enabled: true
@@ -33,6 +52,7 @@ sass:
 plugins:
   - jekyll-include-cache
   - jekyll-feed
+  - jekyll-seo-tag
 
 # Include generated plot files in the site
 include:

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -7,15 +7,6 @@
 <meta property="og:description" content="{{ site.description | default: 'A curated collection of notable quantum computing experiments' }}">
 <meta property="og:image" content="{{ site.url }}{{ '/assets/social_image.png' | relative_url }}">
 
-<!-- Twitter Card meta tags -->
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:url" content="{{ site.url }}{{ site.baseurl }}/">
-<meta name="twitter:title" content="{{ site.title | default: 'Awesome Quantum Computing Experiments' }}">
-<meta name="twitter:description" content="{{ site.description | default: 'A curated collection of notable quantum computing experiments' }}">
-<meta name="twitter:creator" content="@fm_leregent">
-<meta name="twitter:site" content="@fm_leregent">
-<meta name="twitter:image" content="{{ site.url }}{{ '/assets/social_image.png' | relative_url }}">
-
 <!-- Favicon -->
 <link rel="icon" type="image/png" href="{{ '/assets/atom-emoji.png' | relative_url }}">
 


### PR DESCRIPTION
This pull request introduces the Jekyll SEO Tag plugin to the project and updates the configuration to enhance SEO and social media integration. The changes include adding the plugin, configuring social media settings, and removing custom Twitter meta tags in favor of the plugin's built-in functionality.

### SEO and Social Media Enhancements:
* **Added Jekyll SEO Tag plugin**: Included the `jekyll-seo-tag` gem in the `Gemfile` and `_config.yml` to enable SEO features. [[1]](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR25) [[2]](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883R55)
* **Configured social media settings**: Updated `_config.yml` to include Twitter and social media configurations, such as username, card type, social links, and a default social image.

### Code Simplification:
* **Removed custom Twitter meta tags**: Deleted redundant Twitter Card meta tags from `_includes/head_custom.html`, as these are now handled by the Jekyll SEO Tag plugin.