### PR TITLE
GH CI: generate plots and readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - 'feature/**'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[test]"
+    
+    - name: Run tests
+      run: |
+        pytest tests/
+    
+  generate:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[test]"
+    
+    - name: Generate plots and README
+      run: |
+        make all
+    
+    - name: Commit and push if changed
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add -A
+        git diff --quiet && git diff --staged --quiet || (git commit -m "Update plots and README [skip ci]" && git push) 


### PR DESCRIPTION
This pull request introduces (back) a new GitHub Actions workflow to automate continuous integration (CI) processes, including testing and generating updated plots and documentation. 

### CI Workflow Setup:

* `.github/workflows/ci.yml`: Added a new workflow named "CI" that triggers on pushes to the `main` branch, feature branches (`feature/**`), and pull requests targeting `main`. It includes two jobs:
  - **Test job**: Runs tests using `pytest` after setting up Python 3.10 and installing dependencies.
  - **Generate job**: Executes after the test job on pushes to `main`. It generates plots and README updates using `make`, and commits and pushes changes if any files are updated.