### PR TITLE
Update msd_exp.csv

### DIFF
--- a/data/msd_exp.csv
+++ b/data/msd_exp.csv
@@ -1,3 +1,4 @@
 "Code Name","Article Title","Link","Year","Platform","Notes"
 "1 to 1","Scaling and logic in the color code on a superconducting quantum processor","https://arxiv.org/abs/2412.14256","2024","Superconducting circuit","Injection and teleportation"
 "5 to 1","Experimental Demonstration of Logical Magic State Distillation","https://arxiv.org/abs/2412.15165","2024","Neutral atoms","Injection and distillation"
+"4 to 2","Experimental purification of two-atom entanglement","https://doi.org/10.1038/nature05146","2006","Ion traps","9Be+ atomic ion qubits. Distillation: Two noisy entangled pairs were created and distilled into one higher-fidelity pair available for further use. Unpurified fidelity of 0.614 +- 0.0015, and a purified fidelity of 0.629 +- 0.0015"


### PR DESCRIPTION
This pull request adds a new experimental result to the `data/msd_exp.csv` file, expanding the dataset with an important early demonstration of entanglement purification using ion traps.

Data update:

* Added a new entry for a 2006 experiment on the purification of two-atom entanglement with ion traps, including details on the protocol, platform, and achieved fidelities.