### PR TITLE
Change fit name from '×2' to '÷2' in entangled error plot

### DIFF
--- a/src/plotting/entangled_error_plot.py
+++ b/src/plotting/entangled_error_plot.py
@@ -131,7 +131,7 @@ class EntangledErrorPlot(BasePlot):
                     'type': 'scatter',
                     'x': x_fit.tolist(),
                     'y': y_fit.tolist(),
-                    'name': f'{platform} fit (×2 every {doubling_time:.1f}y)',
+                    'name': f'{platform} fit (÷2 every {doubling_time:.1f}y)',
                     'mode': 'lines',
                     'line': {
                         'color': self.PLATFORM_COLORS.get(platform),


### PR DESCRIPTION
This pull request makes a small but important correction to the labeling of fitted trend lines in the entangled error plot. The label now correctly indicates that the metric is halving (÷2) rather than doubling (×2) every specified number of years.

* Corrected the fit line label in `create_plot` of `entangled_error_plot.py` to show "÷2 every Xy" instead of "×2 every Xy", accurately reflecting the trend direction.