### PR TITLE
Update Twitter and Open Graph image URLs

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,7 +10,7 @@
   <meta name="twitter:description" content="{{ site.description | default: 'A curated collection of notable quantum computing experiments' }}">
   <meta name="twitter:creator" content="@fm_leregent">
   <meta name="twitter:site" content="@fm_leregent">
-  <meta name="twitter:image" content="https://francoismarieleregent.xyz/assets/social_image.png">
+  <meta name="twitter:image" content="https://francoismarieleregent.xyz/img/user/social_image_aqce.png">
   <meta name="twitter:image:alt" content="Awesome Quantum Computing Experiments - Explore Notable Trends in Quantum Computing with visualization of QEC implementations">
 
   <!-- Basic SEO meta tags -->
@@ -23,7 +23,7 @@
   <meta property="og:type" content="website">
   <meta property="og:title" content="{{ page.title | default: site.title | default: 'Awesome Quantum Computing Experiments' }}">
   <meta property="og:description" content="{{ page.description | default: site.description | default: 'A curated collection of notable quantum computing experiments' }}">
-  <meta property="og:image" content="{{ site.url }}{{ '/assets/social_image.png' | relative_url }}">
+  <meta property="og:image" content="https://francoismarieleregent.xyz/img/user/social_image_aqce.png">
   <meta property="og:site_name" content="{{ site.title }}">
 
   <!-- JSON-LD structured data for Google -->


### PR DESCRIPTION
This pull request updates the social sharing images for the website to use a new image path. The changes ensure that both Twitter and Open Graph meta tags reference the updated image, which will be displayed when the site is shared on social media platforms.

Social media meta tag updates:

* Updated the Twitter `meta` tag for `twitter:image` to use the new image URL `https://francoismarieleregent.xyz/img/user/social_image_aqce.png` in `_includes/head.html`.
* Updated the Open Graph `meta` tag for `og:image` to use the same new image URL in `_includes/head.html`.